### PR TITLE
refactor(render): use SharedArrayBuffer

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,10 @@
       }
     ],
     "security": {
+      "headers": {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp"
+      },
       "csp": null
     }
   },

--- a/src/lib/player/Player.svelte
+++ b/src/lib/player/Player.svelte
@@ -51,6 +51,7 @@
   let showProgress = true;
   let renderingDetail = '';
   let renderingOutput = '';
+  let lastProgressBarPercent = 0;
 
   let status = GameStatus.LOADING;
   let duration = 0;
@@ -112,10 +113,13 @@
       renderingETA =
         ((Date.now() - renderingStarted) / 1000 / Math.min(renderingProgress, renderingTotal)) *
         Math.max(renderingTotal - renderingProgress, 0);
-      getCurrentWebviewWindow().setProgressBar({
-        status: ProgressBarStatus.Normal,
-        progress: Math.round(renderingPercent * 100),
-      });
+      if (renderingPercent - lastProgressBarPercent >= 0.01) {
+        getCurrentWebviewWindow().setProgressBar({
+          status: ProgressBarStatus.Normal,
+          progress: Math.round(renderingPercent * 100),
+        });
+        lastProgressBarPercent = renderingPercent;
+      }
     });
 
     EventBus.on('video-rendering-finished', () => {


### PR DESCRIPTION
Use SharedArrayBuffer to share frame data with the FrameSender Worker. This in theory could speed up frame transmission between the main thread and the Worker thread. Benchmark tests are to be conducted.